### PR TITLE
fix: search wasn't looking in note text. focuses on previous window after writing note. 

### DIFF
--- a/src/main/app/index.ts
+++ b/src/main/app/index.ts
@@ -105,10 +105,20 @@ class App {
             appUpdater();
         }
 
+        // Gives focus back to previous window
         ipcMain.on('kb::hide-search', () => {
             if (this.editorWindow &&
                 this.editorWindow.browserWindow &&
                 !this.editorWindow.browserWindow.isVisible()) {
+                app.hide();
+            }
+        });
+
+        // Gives focus back to previous window
+        ipcMain.on('kb::hide-editor', () => {
+            if (this.searchWindow &&
+                this.searchWindow.browserWindow &&
+                !this.searchWindow.browserWindow.isVisible()) {
                 app.hide();
             }
         });

--- a/src/main/filemanager.ts
+++ b/src/main/filemanager.ts
@@ -112,6 +112,7 @@ class FileManager extends EventEmitter {
             this._index.search(query, {
                 fields: {
                     title: { boost: 2 },
+                    text: { boost: 1 },
                 },
                 bool: 'OR',
                 expand: true,

--- a/src/main/windows/base.ts
+++ b/src/main/windows/base.ts
@@ -53,7 +53,6 @@ class BaseWindow extends EventEmitter {
                     if (this.type === WindowType.SEARCH) {
                         this.browserWindow.webContents.send('rnd::hide-search')
                     } else if (this.type === WindowType.EDITOR) {
-                        this.browserWindow.webContents.send('rnd::clear-doc')
                         this.browserWindow.webContents.send('rnd::hide-editor')
                     }
 

--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -9,6 +9,7 @@ export interface Props {
     setMarkdown: (markdown: string) => void;
     readOnly?: boolean;
     activeIdx?: string | undefined;
+    autoFocus?: boolean;
 }
 
 const Markdown: React.FunctionComponent<Props> = (
@@ -17,7 +18,8 @@ const Markdown: React.FunctionComponent<Props> = (
         setMarkdown, 
         onSave, 
         readOnly = false, 
-        activeIdx=undefined,
+        activeIdx = undefined,
+        autoFocus = false,
     }
 ) => (
     <MarkdownDiv>
@@ -29,6 +31,7 @@ const Markdown: React.FunctionComponent<Props> = (
             onCancel={null}
             onChange={setMarkdown}
             readOnly={readOnly}
+            autoFocus={autoFocus}
         />
     </MarkdownDiv>
 );

--- a/src/renderer/components/Title.tsx
+++ b/src/renderer/components/Title.tsx
@@ -5,9 +5,14 @@ import styled from 'styled-components';
 export interface Props {
     title: string;
     setTitle: (title: string) => void;
+    autoFocus: boolean;
 }
 
-const Title: React.FunctionComponent<Props> = ({ title, setTitle }) => (
+const Title: React.FunctionComponent<Props> = ({ 
+    title, 
+    setTitle, 
+    autoFocus,
+}) => (
     <FieldContainer>
         <StyledInput
             autoFocus={true}

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -17,12 +17,13 @@ const initialState = window.INITIAL_REDUX_STATE;
 const store = configureStore(history, initialState);
 
 
-import { clearDoc } from './stores/editor/actions';
+import { clearDoc, forceRender } from './stores/editor/actions';
 import { clearSearch, setQuery } from './stores/search/actions';
 
 
 ipcRenderer.on('rnd::clear-doc', (e) => {
     store.dispatch(clearDoc());
+    store.dispatch(forceRender());
 })
 
 ipcRenderer.on('rnd::clear-search', (e) => {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -31,7 +31,11 @@ ipcRenderer.on('rnd::clear-search', (e) => {
 });
 
 ipcRenderer.on('rnd::hide-search', (e) => {
-    ipcRenderer.send('kb::hide-search')
+    ipcRenderer.send('kb::hide-search');
+});
+
+ipcRenderer.on('rnd::hide-editor', (e) => {
+    ipcRenderer.send('kb::hide-editor');
 });
 
 

--- a/src/renderer/pages/editor.tsx
+++ b/src/renderer/pages/editor.tsx
@@ -76,13 +76,21 @@ class EditorPage extends React.Component<AllProps> {
 
         const doc: Document = { id, title, markdown };
 
+        // autofocus text box on update
+        const afEditor: boolean = (!id) ? false : true;
+        const afTitle: boolean = (!id) ? true : false;
+
         return (
             <Page>
                 <SearchTitleContainer>
-                    <Title title={title} setTitle={setTitle} />
+                    <Title 
+                      autoFocus={afTitle} 
+                      title={title} 
+                      setTitle={setTitle} />
                 </SearchTitleContainer>
                 <EditorContainer>
                     <Markdown 
+                      autoFocus={afEditor}
                       key={renderIdx}
                       onSave={() => saveRequest(doc)}
                       setMarkdown={this.handleMarkdownChange.bind(this)} 

--- a/src/renderer/stores/editor/reducer.ts
+++ b/src/renderer/stores/editor/reducer.ts
@@ -25,7 +25,12 @@ const reducer: Reducer<EditorState> = (state = initialState, action) => {
         return { ...state, markdown: action.payload };
     }
     case EditorActionTypes.SAVE_SUCCESS: {
-        return { ...state, id: '', markdown: '', title: '' };
+        return { 
+            ...state, 
+            id: '', 
+            markdown: '', 
+            title: '', 
+            renderIdx: state.renderIdx + 1};
     }
     case EditorActionTypes.CLEAR_DOC: {
         return { ...initialState }

--- a/src/renderer/stores/editor/sagas.ts
+++ b/src/renderer/stores/editor/sagas.ts
@@ -2,7 +2,13 @@ import { all, call, fork, put, takeEvery, takeLatest, select } from 'redux-saga/
 import { ipcRenderer } from 'electron'
 import { v4 as uuid } from 'uuid';
 import { EditorActionTypes } from './types';
-import { saveError, saveSuccess, setTitle, setMarkdown } from './actions'
+import { 
+    saveError, 
+    saveSuccess, 
+    setTitle, 
+    setMarkdown,
+    forceRender,
+} from './actions'
 import { callApi } from '../../utils/api'
 
 
@@ -18,8 +24,16 @@ function* handleSave() {
             isUpdate: !!state.editor.id
         }
         ipcRenderer.send('kb::hide-editor')
-        ipcRenderer.send('fm::save', data.id, data.title, data.text, data.isUpdate)
-        ipcRenderer.send('kb::new-document', data)
+
+        if (data.title) {
+            ipcRenderer.send(
+                'fm::save', 
+                data.id, 
+                data.title, 
+                data.text, 
+                data.isUpdate)
+            ipcRenderer.send('kb::new-document', data)
+        }
         yield put(saveSuccess(data))
         
         /* REMOVED BECAUSE WE ARE NOT USING AN API. 


### PR DESCRIPTION
Adds feature to focus on previous window when hiding or saving editor.
Adds feature to focus on text when updating a note.
Fixes bug where search wasn't looking in note body.

fix #29 
fix #31 
fix #30